### PR TITLE
Stop event propagation if validation failed.

### DIFF
--- a/jquery-validate.js
+++ b/jquery-validate.js
@@ -374,6 +374,7 @@
 							} else {
 
 								event.preventDefault();
+                event.stopImmediatePropagation();
 
 								// Is a function?
 								if($.isFunction(options.invalid)) {


### PR DESCRIPTION
If form validation failed, the event propagation should be stopped to prevent the subsequent event handers bound to form's submit event be executed.
